### PR TITLE
Fix meteor destruction ellipse check

### DIFF
--- a/Assets/Scripts/Meteor/MeteorMovement.cs
+++ b/Assets/Scripts/Meteor/MeteorMovement.cs
@@ -76,8 +76,10 @@ public class MeteorMovement : MonoBehaviour
     private bool IsInsideEllipse(float threshold)
     {
         Vector3 localPos = transform.position - ellipseCenter;
-        float xComponent = (localPos.x * localPos.x) / (ellipseWidth * ellipseWidth);
-        float yComponent = (localPos.y * localPos.y) / (ellipseHeight * ellipseHeight);
+        float semiMajor = ellipseWidth / 2f;
+        float semiMinor = ellipseHeight / 2f;
+        float xComponent = (localPos.x * localPos.x) / (semiMajor * semiMajor);
+        float yComponent = (localPos.y * localPos.y) / (semiMinor * semiMinor);
 
         return xComponent + yComponent <= threshold;
     }


### PR DESCRIPTION
## Summary
- fix ellipse check by using semi-major/minor axes in `MeteorMovement`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684980abe4e0832d97b375876f86f34f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of meteor boundary detection within ellipses, ensuring more reliable entry and destruction checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->