### PR TITLE
Add Splash Screen Scene and Transition to Main Menu

### DIFF
--- a/Assets/Scripts/Controllers/SplashScreenController.cs
+++ b/Assets/Scripts/Controllers/SplashScreenController.cs
@@ -3,7 +3,8 @@ using UnityEngine.SceneManagement;
 
 public class SplashScreenController : MonoBehaviour
 {
-    public float delay = 10f; // Set the delay to 10 seconds 
+    // Delay before loading the main menu
+    public float delay = 2f;
 
     // Start is called before the first frame update
     void Start()

--- a/Assets/Tests/PlayMode/SplashScreenTests.cs
+++ b/Assets/Tests/PlayMode/SplashScreenTests.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using System.Collections;
+
+public class SplashScreenTests
+{
+    [UnityTest]
+    public IEnumerator SplashScreen_AutoLoadsMainMenu()
+    {
+        SceneManager.LoadScene("SplashScreen");
+        yield return null; // allow scene to load
+        yield return new WaitForSeconds(2.5f);
+        Assert.AreEqual("MainMenu", SceneManager.GetActiveScene().name);
+    }
+}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,13 +5,10 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/SplashScreen.unity
     guid: 38c4cb66829ad9343b8f43e4ccaa750c
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/MainMenu.unity
     guid: d845db54b92977447afd5c1935279d20
   - enabled: 1


### PR DESCRIPTION
## Summary
- update splash screen delay to 2 seconds
- enable SplashScreen and MainMenu scenes in build settings
- add play mode test for splash screen transition

## Testing
- `unity-editor -quit -batchmode -runTests -projectPath . -testPlatform playmode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f114c8f20832d86e64d08a23731ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the splash screen delay before loading the main menu from 10 seconds to 2 seconds for a faster user experience.

* **Tests**
  * Added a new automated test to verify that the splash screen transitions to the main menu after a short delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->