### PR TITLE
Add momentum-based meteor splitting

### DIFF
--- a/Assets/Scripts/Meteor/MeteorMovement.cs
+++ b/Assets/Scripts/Meteor/MeteorMovement.cs
@@ -8,13 +8,19 @@ public class MeteorMovement : MonoBehaviour
     private float speed; // Speed of the meteor
     private float rotationSpeed; // Speed and direction of rotation
 
+    public Vector3 CurrentDirection => direction;
+    public float CurrentSpeed => speed;
+
     // Camera and margin
     private Camera mainCamera;
     private float spawnMargin = 1f;
 
     void Start()
     {
-        speed = Random.Range(minSpeed, maxSpeed);
+        if (speed <= 0f)
+        {
+            speed = Random.Range(minSpeed, maxSpeed);
+        }
         rotationSpeed = Random.Range(-180f, 180f);
 
         MeteorSpawner spawner = FindObjectOfType<MeteorSpawner>();
@@ -33,6 +39,13 @@ public class MeteorMovement : MonoBehaviour
     public void SetInitialDirection(Vector3 initialDirection)
     {
         direction = initialDirection.normalized;
+    }
+
+    public void InitializeMovement(Vector3 dir, float spd)
+    {
+        direction = dir.normalized;
+        speed = spd;
+        rotationSpeed = Random.Range(-180f, 180f);
     }
 
     void Update()

--- a/Assets/Scripts/Meteor/MeteorSplit.cs
+++ b/Assets/Scripts/Meteor/MeteorSplit.cs
@@ -14,6 +14,26 @@ public class MeteorSplit : MonoBehaviour
 
     private bool collisionSplitEnabled = false;
 
+    private void Awake()
+    {
+        MeteorSpawner spawner = FindObjectOfType<MeteorSpawner>();
+        if (spawner != null)
+        {
+            if (mediumBrownMeteors == null || mediumBrownMeteors.Length == 0)
+                mediumBrownMeteors = spawner.mediumBrownMeteors;
+            if (smallBrownMeteors == null || smallBrownMeteors.Length == 0)
+                smallBrownMeteors = spawner.smallBrownMeteors;
+            if (tinyBrownMeteors == null || tinyBrownMeteors.Length == 0)
+                tinyBrownMeteors = spawner.tinyBrownMeteors;
+            if (mediumGreyMeteors == null || mediumGreyMeteors.Length == 0)
+                mediumGreyMeteors = spawner.mediumGreyMeteors;
+            if (smallGreyMeteors == null || smallGreyMeteors.Length == 0)
+                smallGreyMeteors = spawner.smallGreyMeteors;
+            if (tinyGreyMeteors == null || tinyGreyMeteors.Length == 0)
+                tinyGreyMeteors = spawner.tinyGreyMeteors;
+        }
+    }
+
     private void OnEnable()
     {
         collisionSplitEnabled = false;

--- a/Assets/Scripts/Meteor/MeteorSplit.cs
+++ b/Assets/Scripts/Meteor/MeteorSplit.cs
@@ -10,6 +10,21 @@ public class MeteorSplit : MonoBehaviour
     public GameObject[] tinyGreyMeteors;
 
     public float collisionSplitSpeedThreshold = 0.5f;
+    public float collisionSplitEnableDelay = 0.5f;
+
+    private bool collisionSplitEnabled = false;
+
+    private void OnEnable()
+    {
+        collisionSplitEnabled = false;
+        StartCoroutine(EnableCollisionSplit());
+    }
+
+    private System.Collections.IEnumerator EnableCollisionSplit()
+    {
+        yield return new WaitForSeconds(collisionSplitEnableDelay);
+        collisionSplitEnabled = true;
+    }
 
     public void Split()
     {
@@ -119,6 +134,11 @@ public class MeteorSplit : MonoBehaviour
 
     private void OnCollisionEnter2D(Collision2D collision)
     {
+        if (!collisionSplitEnabled)
+        {
+            return;
+        }
+
         MeteorSplit other = collision.gameObject.GetComponent<MeteorSplit>();
         if (other == null)
         {


### PR DESCRIPTION
## Summary
- expose movement data via `CurrentDirection` and `CurrentSpeed`
- allow meteors to initialize movement explicitly
- spawn split meteors with momentum and disperse direction
- let hammer/projectile hits and collisions break meteors preserving momentum

## Testing
- `mcs --version` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68600ef2c87c832db860c58fe435d02b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meteors now retain and propagate their movement direction and speed when splitting, resulting in more realistic and physically accurate meteor fragments.
  * Meteors can now split upon sufficiently fast collisions with other meteors, based on a configurable speed threshold.
  * Exposed properties for current meteor direction and speed, allowing for greater control and visibility of meteor movement.
  * Added a delay before collision-based splitting activates to improve gameplay dynamics.
  * Introduced a method to externally initialize meteor movement direction, speed, and rotation.

* **Improvements**
  * Enhanced splitting behavior when meteors are hit by projectiles or hammers to account for momentum.
  * Initialized meteor arrays from spawner automatically if unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->