### PR TITLE
Add menu flow scripts and settings scene entry

### DIFF
--- a/Assets/Scenes/Settings.unity
+++ b/Assets/Scenes/Settings.unity
@@ -215,8 +215,53 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1854387500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1854387502}
+  - component: {fileID: 1854387501}
+  m_Layer: 0
+  m_Name: SettingsController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1854387501
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854387500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f28a351b726e406e97e061311e554012, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!4 &1854387502
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854387500}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1854387499}
+  - {fileID: 1854387502}

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -1,8 +1,25 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+// Displays a simple main menu with buttons for navigating to the
+// Game and Settings scenes.
+
 public class MainMenuController : MonoBehaviour
 {
+    void OnGUI()
+    {
+        GUILayout.BeginArea(new Rect(Screen.width / 2 - 100, Screen.height / 2 - 50, 200, 100));
+        if (GUILayout.Button("New Game"))
+        {
+            StartGame();
+        }
+        if (GUILayout.Button("Settings"))
+        {
+            OpenSettings();
+        }
+        GUILayout.EndArea();
+    }
+
     public void StartGame()
     {
         SceneManager.LoadScene("Game");

--- a/Assets/Scripts/Controllers/SettingsController.cs
+++ b/Assets/Scripts/Controllers/SettingsController.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class SettingsController : MonoBehaviour
+{
+    private bool changesMade;
+    private float exampleSetting = 0.5f;
+
+    void OnGUI()
+    {
+        GUILayout.BeginArea(new Rect(Screen.width / 2 - 100, Screen.height / 2 - 75, 200, 150));
+        GUILayout.Label("Settings Placeholder");
+        float newVal = GUILayout.HorizontalSlider(exampleSetting, 0f, 1f);
+        if (newVal != exampleSetting)
+        {
+            exampleSetting = newVal;
+            changesMade = true;
+        }
+
+        if (GUILayout.Button("Save"))
+        {
+            // Placeholder save action
+            changesMade = false;
+        }
+
+        if (GUILayout.Button(changesMade ? "Cancel" : "Back"))
+        {
+            SceneManager.LoadScene("MainMenu");
+        }
+        GUILayout.EndArea();
+    }
+}

--- a/Assets/Scripts/Controllers/SettingsController.cs.meta
+++ b/Assets/Scripts/Controllers/SettingsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f28a351b726e406e97e061311e554012
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,4 +14,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Game.unity
     guid: f8302e9802c20c245a1aa514f32183f2
+  - enabled: 1
+    path: Assets/Scenes/Settings.unity
+    guid: dcae348c237f60b4ab1f170608ea89ce
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- build simple menu system using OnGUI
- create placeholder settings controller
- register Settings scene in build settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686025222990832d8e211d134daccd0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a main menu interface with "New Game" and "Settings" buttons for navigation.
  * Added a settings screen with a slider for adjusting a setting, along with "Save" and "Cancel/Back" buttons for managing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->